### PR TITLE
Increase motor constants

### DIFF
--- a/models/rotors_description/urdf/iris.xacro
+++ b/models/rotors_description/urdf/iris.xacro
@@ -48,7 +48,7 @@
   <xacro:property name="arm_length_back_y" value="0.2" /> <!-- [m] -->
   <xacro:property name="rotor_offset_top" value="0.023" /> <!-- [m] -->
   <xacro:property name="radius_rotor" value="0.128" /> <!-- [m] -->
-  <xacro:property name="motor_constant" value="4.274e-06" /> <!-- [kg.m/s^2] -->
+  <xacro:property name="motor_constant" value="5.84e-06" /> <!-- [kg.m/s^2] -->
   <xacro:property name="moment_constant" value="0.06" /> <!-- [m] -->
   <xacro:property name="time_constant_up" value="0.0125" /> <!-- [s] -->
   <xacro:property name="time_constant_down" value="0.025" /> <!-- [s] -->


### PR DESCRIPTION
**Describe problem solved by this pull request**
Previously SITL tests were failing because the hover thrust was too low, which was decreased in PX4/sitl_gazebo#575

Now, SITL tests have been failing since we decreased the motor constants on the iris since the hover thrust was too high

@bresch FYI