### PR TITLE
Fix visualization plugin

### DIFF
--- a/include/force_visual/force_visual.h
+++ b/include/force_visual/force_visual.h
@@ -39,6 +39,10 @@ namespace gazebo
     private: transport::SubscriberPtr subs;
     private: transport::NodePtr node;
     private: rendering::DynamicLinesPtr forceVector;
+
+    private: std::string frameLinkName;
+    private: rendering::VisualPtr host;
+    private: double forceScale = 1.0;
   };
 }
 

--- a/models/plane/plane.sdf.jinja
+++ b/models/plane/plane.sdf.jinja
@@ -192,7 +192,9 @@
         </material>
         <plugin name="left_elevon_lift_visual" filename="libForceVisual.so">
           <topic_name>lift_force/left_elevon</topic_name>
-          <color>Gazebo/Green</color>
+          <color>Gazebo/Red</color>
+          <link_name>base_link</link_name>  <!--This is the link that is actually subjected to force, depending on the libLiftDragPlugin settings. -->
+          <scale>0.1</scale>  <!-- Scale of the force visual, Adjust the appropriate value according to the model. -->
         </plugin>
       </visual>
     </link>
@@ -225,7 +227,9 @@
         </material>
         <plugin name="right_elevon_lift_visual" filename="libForceVisual.so">
           <topic_name>lift_force/right_elevon</topic_name>
-          <color>Gazebo/Green</color>
+          <color>Gazebo/Red</color>
+          <link_name>base_link</link_name>  <!--This is the link that is actually subjected to force, depending on the libLiftDragPlugin settings. -->
+          <scale>0.1</scale>  <!-- Scale of the force visual, Adjust the appropriate value according to the model. -->
         </plugin>
       </visual>
     </link>
@@ -258,7 +262,9 @@
         </material>
         <plugin name="left_flap_lift_visual" filename="libForceVisual.so">
           <topic_name>lift_force/left_flap</topic_name>
-          <color>Gazebo/Green</color>
+          <color>Gazebo/Red</color>
+          <link_name>base_link</link_name>  <!--This is the link that is actually subjected to force, depending on the libLiftDragPlugin settings. -->
+          <scale>0.1</scale>  <!-- Scale of the force visual, Adjust the appropriate value according to the model. -->
         </plugin>
       </visual>
     </link>
@@ -291,7 +297,9 @@
         </material>
         <plugin name="right_elevon_lift_visual" filename="libForceVisual.so">
           <topic_name>lift_force/right_flap</topic_name>
-          <color>Gazebo/Green</color>
+          <color>Gazebo/Red</color>
+          <link_name>base_link</link_name>  <!--This is the link that is actually subjected to force, depending on the libLiftDragPlugin settings. -->
+          <scale>0.1</scale>  <!-- Scale of the force visual, Adjust the appropriate value according to the model. -->
         </plugin>
       </visual>
     </link>
@@ -324,7 +332,9 @@
         </material>
         <plugin name="elevator_lift_visual" filename="libForceVisual.so">
           <topic_name>lift_force/elevator</topic_name>
-          <color>Gazebo/Green</color>
+          <color>Gazebo/Red</color>
+          <link_name>base_link</link_name>  <!--This is the link that is actually subjected to force, depending on the libLiftDragPlugin settings. -->
+          <scale>0.1</scale>  <!-- Scale of the force visual, Adjust the appropriate value according to the model. -->
         </plugin>
       </visual>
     </link>
@@ -357,7 +367,9 @@
         </material>
         <plugin name="rudder_lift_visual" filename="libForceVisual.so">
           <topic_name>lift_force/rudder</topic_name>
-          <color>Gazebo/Green</color>
+          <color>Gazebo/Red</color>
+          <link_name>base_link</link_name>  <!--This is the link that is actually subjected to force, depending on the libLiftDragPlugin settings. -->
+          <scale>0.1</scale>  <!-- Scale of the force visual, Adjust the appropriate value according to the model. -->
         </plugin>
       </visual>
     </link>
@@ -511,7 +523,7 @@
       <forward>1 0 0</forward>
       <upward>0 0 1</upward>
       <link_name>base_link</link_name>
-      <topic_name>lift_force/left_elevon</topic_name> <!--Uncomment to draw the force-->
+      <topic_name>lift_force/left_elevon</topic_name> <!--The origin of force will be the value set by the <cp> tag.-->
       <control_joint_name>
         left_elevon_joint
       </control_joint_name>
@@ -534,7 +546,7 @@
       <forward>1 0 0</forward>
       <upward>0 0 1</upward>
       <link_name>base_link</link_name>
-      <topic_name>lift_force/right_elevon</topic_name> <!--Uncomment to draw the force-->
+      <topic_name>lift_force/right_elevon</topic_name> <!--The origin of force will be the value set by the <cp> tag.-->
       <control_joint_name>
         right_elevon_joint
       </control_joint_name>
@@ -557,7 +569,7 @@
       <forward>1 0 0</forward>
       <upward>0 0 1</upward>
       <link_name>base_link</link_name>
-      <topic_name>lift_force/left_flap</topic_name> <!--Uncomment to draw the force-->
+      <topic_name>lift_force/left_flap</topic_name> <!--The origin of force will be the value set by the <cp> tag.-->
       <control_joint_name>
         left_flap_joint
       </control_joint_name>
@@ -580,7 +592,7 @@
       <forward>1 0 0</forward>
       <upward>0 0 1</upward>
       <link_name>base_link</link_name>
-      <topic_name>lift_force/right_flap</topic_name> <!--Uncomment to draw the force-->
+      <topic_name>lift_force/right_flap</topic_name> <!--The origin of force will be the value set by the <cp> tag.-->
       <control_joint_name>
         right_flap_joint
       </control_joint_name>
@@ -603,7 +615,7 @@
       <forward>1 0 0</forward>
       <upward>0 0 1</upward>
       <link_name>base_link</link_name>
-      <topic_name>lift_force/elevator</topic_name> <!--Uncomment to draw the force-->
+      <topic_name>lift_force/elevator</topic_name> <!--The origin of force will be the value set by the <cp> tag.-->
       <control_joint_name>
         elevator_joint
       </control_joint_name>
@@ -626,7 +638,7 @@
       <forward>1 0 0</forward>
       <upward>0 1 0</upward>
       <link_name>base_link</link_name>
-      <topic_name>lift_force/rudder</topic_name> <!--Uncomment to draw the force-->
+      <topic_name>lift_force/rudder</topic_name> <!--The origin of force will be the value set by the <cp> tag.-->
       <control_joint_name>
          rudder_joint
       </control_joint_name>

--- a/src/liftdrag_plugin/liftdrag_plugin.cpp
+++ b/src/liftdrag_plugin/liftdrag_plugin.cpp
@@ -435,7 +435,7 @@ void LiftDragPlugin::OnUpdate()
   this->link->AddForceAtRelativePosition(force, this->cp);
   this->link->AddTorque(moment);
 
-  auto relative_center = + this->cp;
+  auto relative_center = this->cp;
 
   // Publish force and center of pressure for potential visual plugin.
   // - dt is used to control the rate at which the force is published

--- a/src/liftdrag_plugin/liftdrag_plugin.cpp
+++ b/src/liftdrag_plugin/liftdrag_plugin.cpp
@@ -435,7 +435,7 @@ void LiftDragPlugin::OnUpdate()
   this->link->AddForceAtRelativePosition(force, this->cp);
   this->link->AddTorque(moment);
 
-  auto relative_center = this->link->RelativePose().Pos() + this->cp;
+  auto relative_center = + this->cp;
 
   // Publish force and center of pressure for potential visual plugin.
   // - dt is used to control the rate at which the force is published


### PR DESCRIPTION
The force visualization plugin is affected  by link's visual effects, leading to incorrect force application points. This submission aims to fix the issue. the test based on px4 v1.15.4 and corresponding gazebo-classic commit ID is  `da7206e057703cc645770f02437013358b71e1c0`.

- Old version, the force origin is at 0.07 0.0 -0.08 0.00 0 0.0, which is the position of the `visual` tag, but actually not the position of the force's point of action:

![default_gzclient_camera(1)-2025-08-11T16_11_01 068983](https://github.com/user-attachments/assets/053032e6-21bd-4c0d-851c-4de3bce2b1bc)


- New version, the point of force is set at the position defined by the `cp` tag:
![default_gzclient_camera(1)-2025-08-11T16_23_37 538376](https://github.com/user-attachments/assets/7868aa22-1cc6-4c36-9ca5-bc7c9af939eb)


![default_gzclient_camera(1)-2025-08-11T16_23_40 233937](https://github.com/user-attachments/assets/1a3769ad-e1b0-4d0f-9fa4-c63967618215)


![default_gzclient_camera(1)-2025-08-11T16_23_38 561851](https://github.com/user-attachments/assets/eb39327a-37e7-4053-9651-c83fde5b2674)


For other models that call this plugin, such as `PX4-Autopilot/Tools/simulation/gazebo-classic/sitl_gazebo-classic/models/advanced_plane/advanced_plane.sdf.jinja` and  `PX4-Autopilot/Tools/simulation/gazebo-classic/sitl_gazebo-classic/models/glider/glider.sdf`, I don't have equipment to test them, but I tried using old settings for `plane.sdf`, and they will display force as "expected", as shown in following green line:

![default_gzclient_camera(1)-2025-08-11T16_55_42 899508](https://github.com/user-attachments/assets/0512aec5-01d1-47b0-bcd0-03d09dbd8a9b)
