### PR TITLE
fix(gimbal): Added missing cap_flags2 parameter

### DIFF
--- a/src/gazebo_gimbal_controller_plugin.cpp
+++ b/src/gazebo_gimbal_controller_plugin.cpp
@@ -683,7 +683,8 @@ void GimbalControllerPlugin::SendGimbalDeviceInformation()
     pitchMax,
     yawMin,
     yawMax,
-    0 /*gimbal_device_id*/);
+    0, /*gimbal_device_id*/
+    0  /*cap_flags2*/);
   SendMavlinkMessage(msg);
 }
 


### PR DESCRIPTION
Added missing cap_flags2 parameter to mavlink_msg_gimbal_device_information_pack_chan() call. The MAVLink dialect update added this field to the function signature, breaking the PX4 gazebo-classic build.